### PR TITLE
chore: improved schedule upgrade script

### DIFF
--- a/win/SetupChocolatey.ps1
+++ b/win/SetupChocolatey.ps1
@@ -26,9 +26,12 @@ function ScheduleUpgradeJob() {
         Name = "Chocolatey upgrade"
         ScriptBlock = {choco upgrade all -y}
         Trigger = New-JobTrigger -Weekly -DaysOfWeek Monday, Wednesday, Friday -At "15:00"
-        ScheduledJobOption = New-ScheduledJobOption -RunElevated -MultipleInstancePolicy StopExisting -RequireNetwork
+        ScheduledJobOption = New-ScheduledJobOption -RunElevated -MultipleInstancePolicy StopExisting -RequireNetwork -StartIfOnBattery -ContinueIfGoingOnBattery
     }
     Register-ScheduledJob @ScheduledJob
+    $task = Get-ScheduledTask -TaskName "Chocolatey upgrade"
+    $task.Principal = New-ScheduledTaskPrincipal -UserId "$($env:USERDOMAIN)\$($env:USERNAME)" -LogonType ServiceAccount -RunLevel Highest
+    Set-ScheduledTask $task
 }
 
 function Show-Menu {


### PR DESCRIPTION
Changes:

- [X] Run task when the machine is on battery or is switching to battery
- [X] Added Principal that would avoid the script to run if the service account is not recognised